### PR TITLE
Update to use document instead of document.body

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@
             traverseNodeList(mutation.addedNodes, added);
             traverseNodeList(mutation.removedNodes, removed);
         });
-    }).observe(document.body, {
+    }).observe(document, {
         attributes: false,
         childList: true,
         subtree: true,


### PR DESCRIPTION
I'm attempting to use this library for an Adobe Launch extension and running into errors when rava initializes because Launch can fire from the head rather than page bottom. Since the body has not yet been created, this throws an undefined exception trying to create the MutationObserver with document.body. 