### PR TITLE
Always Bind Window

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@
             traverseNodeList(mutation.addedNodes, added);
             traverseNodeList(mutation.removedNodes, removed);
         });
-    }).observe(document.body, {
+    }).observe(document, {
         attributes: false,
         childList: true,
         subtree: true,

--- a/index.js
+++ b/index.js
@@ -215,7 +215,8 @@
         module.exports = {
             rava: rava
         };
-    } else {
+    }
+    if (typeof window !== 'undefined') {
         window.rava = rava;
     }
 })();


### PR DESCRIPTION
Another fun launch issue. Since launch has a method `module.exports` rava was not being bound to the window which caused issues with using it. Not sure if this is the correct way to resolve this, but it worked for me :-)